### PR TITLE
Additional Tests

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -5,3 +5,11 @@ omit =
     *__init__*
     rivgraph/ordered_set.py
     rivgraph/_plotting_metrics.py
+
+[report]
+exclude_lines =
+    def set_no_backtrack
+    def set_shortest_no_backtrack
+    def set_artificial_nodes
+    def set_unknown_cluster_by_widthpct
+    

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,6 +17,7 @@ from rivgraph.classes import river
 @pytest.fixture(scope="module")
 def test_net():
     """Define the test network."""
+    np.random.seed(1)
     return delta('colville', 'tests/data/Colville/Colville_islands_filled.tif',
                  'tests/results/colville/')
 
@@ -24,6 +25,7 @@ def test_net():
 @pytest.fixture(scope="module")
 def known_net():
     """Define the known network to test against."""
+    np.random.seed(1)
     known_net = delta('known',
                       'tests/data/Colville/Colville_islands_filled.tif',
                       'tests/results/known/')
@@ -34,6 +36,7 @@ def known_net():
 @pytest.fixture(scope="module")
 def test_river():
     """Define the test river network."""
+    np.random.seed(1)
     return river('Brahmclip', 'tests/data/Brahma/brahma_mask_clip.tif',
                  'tests/results/brahma/', exit_sides='ns')
 
@@ -41,6 +44,7 @@ def test_river():
 @pytest.fixture(scope="module")
 def known_river():
     """Define the known river network."""
+    np.random.seed(1)
     known_river = river('Brahmclip', 'tests/data/Brahma/brahma_mask_clip.tif',
                         'tests/results/brahma/', exit_sides='ns')
     known_river.load_network(path='tests/data/Brahma/Brahmclip_network.pkl')
@@ -50,6 +54,7 @@ def known_river():
 @pytest.fixture(scope="module")
 def synthetic_cycles():
     """Creation of synthetic skeleton."""
+    np.random.seed(1)
     # create synthetic binary skeleton
     synthetic = np.zeros((10, 10))
     synthetic[0, 7] = 1

--- a/tests/test_delta.py
+++ b/tests/test_delta.py
@@ -66,6 +66,7 @@ def test_prune_network(test_net, known_net):
 
 def test_flowdir(test_net, known_net):
     """Check that 90% of directions are assigned to match known case."""
+    np.random.seed(1)
     # set directions
     test_net.assign_flow_directions()
 
@@ -103,6 +104,7 @@ def test_flowdir(test_net, known_net):
 
 def test_junction_angles(test_net, known_net):
     """Check that 90% of junction angles agree."""
+    np.random.seed(1)
     # compute the junction angles
     test_net.compute_junction_angles(weight=None)
     known_net.compute_junction_angles(weight=None)
@@ -145,6 +147,7 @@ def test_junction_angles(test_net, known_net):
 # creating a memory overflow warning (sometimes)
 
 def test_metrics(test_net,known_net):
+    np.random.seed(1)
     # compute metrics
     test_net.compute_topologic_metrics()
     known_net.compute_topologic_metrics()

--- a/tests/test_mask_utils.py
+++ b/tests/test_mask_utils.py
@@ -1,0 +1,43 @@
+"""Tests for the mask_utils.py functions."""
+import pytest
+import sys
+import os
+import numpy as np
+sys.path.append(os.path.realpath(os.path.dirname(__file__)+"/.."))
+from rivgraph import mask_utils
+
+
+class TestIslandProps:
+    """Tests associated with get_island_properties()."""
+
+    def test_no_props(self, test_net):
+        """Test, no island properties."""
+        props = []
+        gdf, Ilabel = mask_utils.get_island_properties(test_net.Imask,
+                                                       test_net.pixlen,
+                                                       test_net.pixarea,
+                                                       test_net.crs,
+                                                       test_net.gt,
+                                                       props)
+        # assert image mask size same as labeled image size
+        assert Ilabel.shape == test_net.Imask.shape
+        # make assertion about gdf shape
+        assert np.shape(gdf) == (99, 2)
+
+    @pytest.mark.xfail
+    def test_maxwidth(self, test_net):
+        """Test given maxwidth."""
+        # not implemented yet
+        pass
+
+    @pytest.mark.xfail
+    def test_perimeter(self, test_net):
+        """Test given perimeter."""
+        # not implemented yet
+        pass
+
+    @pytest.mark.xfail
+    def test_islandprops(self, test_net):
+        """Test given island properties."""
+        # not implemented yet
+        pass


### PR DESCRIPTION
Several things here:

- The notes at the bottoms of some of the scripts indicating deprecated functions (to be untested) were helpful as they allowed us to exclude/ignore those from the unit testing

- Tried to standardize some of the tests by setting the random seed for whatever that's worth, not sure if it's helping, but am trying to avoid that issue with the metrics calculation

- Started to add tests for the `mask_utils.py` functions, I know those functions are new so will probably finish those tests once the docstrings are a bit more descriptive there, left some placeholder (x-fail) tests there to remind me to go back and add them.

- Added more unit tests for the `directionality.py` script. Ran into some problems here:

     1. The first was when I tried to write a test for the `fix_cycles()` function ([here](https://github.com/elbeejay/RivGraph/blob/94a9cae84d67e00631c4fbb2e7e769bd9f8ac91c/tests/test_directionality.py#L156)). I have verified that an actual cycle exists (as I flipped a link to create it), but also verify it with the `find_a_cycle()` function within the unit test. We are also checking that there are no continuity problems via `check_continuity()`. However this test is throwing an error related to the edge not being part of the graph when `fix_cycles()` is being called.

     2. The second was when writing the test for the `fix_sources_and_sinks()` function ([here](https://github.com/elbeejay/RivGraph/blob/94a9cae84d67e00631c4fbb2e7e769bd9f8ac91c/tests/test_directionality.py#L189)). In this case we verify that a continuity issue exists (using the `check_continuity()` function). Then when we try to use the `fix_sources_and_sinks()`, we get an error code: `KeyError: 1081`.

So any tips on getting those tests to actually work would be great, right now I'm just allowing them to x-fail.


Last note would be that this PR bumps up the unit test coverage to 80%. So that does bring us up to a less embarrassing unit test coverage. If you wanted to add another badge to the Readme to complement the automated Travis CI badge, you could similarly enable [coveralls](https://coveralls.io/) to get a badge that displays the unit test coverage (the one below is generated from this branch).
 
[![Coverage Status](https://coveralls.io/repos/github/elbeejay/RivGraph/badge.svg?branch=river_tests)](https://coveralls.io/github/elbeejay/RivGraph?branch=river_tests)