### PR TITLE
Test package on all OS with GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,8 +30,11 @@ jobs:
           conda uninstall rivgraph
           pip install pytest pytest-timeout pytest-cov coveralls
           python setup.py install
-
           pytest --cov-config=.coveragerc --cov=rivgraph/
+      - name: get coverage
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
           coveralls
 
   windows-build:
@@ -59,7 +62,6 @@ jobs:
           conda uninstall rivgraph
           pip install pytest pytest-timeout pytest-cov coveralls
           python setup.py install
-
           pytest --cov-config=.coveragerc --cov=rivgraph/
 
   macos-build:
@@ -87,5 +89,4 @@ jobs:
           conda uninstall rivgraph
           pip install pytest pytest-timeout pytest-cov coveralls
           python setup.py install
-
           pytest --cov-config=.coveragerc --cov=rivgraph/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
           python setup.py install
           coverage run -m pytest --cov-config=.coveragerc --cov=rivgraph/
       - name: coveralls
-        uses: coverallsapp/github-action@master
+      - uses: coverallsapp/github-action@master
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,12 +5,12 @@ name: build
 on: [push, pull_request]
 
 jobs:
-  build:
+  ubunutu-build:
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest]
         python-version: [3.6]
     env:
       OS: ${{ matrix.os }}
@@ -22,16 +22,70 @@ jobs:
           mamba-version: "*"
           channels: conda-forge, defaults
       - uses: actions/checkout@v2
-      - name: install RivGraph + dependencies
+      - name: install RivGraph + dependencies, then unit test
         shell: bash -l {0}
         run: |
           mamba env create -q --file environment.yml
           conda activate rivgraph
           conda uninstall rivgraph
-          sudo apt-get install gnutls-bin
           pip install pytest pytest-timeout pytest-cov coveralls
           python setup.py install
-      - name: run unit tests and get coverage
-        run: |
+
           pytest --cov-config=.coveragerc --cov=rivgraph/
           coveralls
+
+  windows-build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest]
+        python-version: [3.6]
+    env:
+      OS: ${{ matrix.os }}
+      PYTHON: ${{ matrix.python-version }}
+    steps:
+      - uses: conda-incubator/setup-miniconda@v1.7.0
+        with:
+          python-version: ${{ matrix.python-version }}
+          miniconda-version: "latest"
+          channels: conda-forge, defaults
+      - uses: actions/checkout@v2
+      - name: install RivGraph + dependencies, then unit test
+        shell: bash -l {0}
+        run: |
+          conda env create -q --file environment.yml
+          conda activate rivgraph
+          conda uninstall rivgraph
+          pip install pytest pytest-timeout pytest-cov coveralls
+          python setup.py install
+
+          pytest --cov-config=.coveragerc --cov=rivgraph/
+
+  macos-build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest]
+        python-version: [3.6]
+    env:
+      OS: ${{ matrix.os }}
+      PYTHON: ${{ matrix.python-version }}
+    steps:
+      - uses: conda-incubator/setup-miniconda@v1.7.0
+        with:
+          python-version: ${{ matrix.python-version }}
+          mamba-version: "*"
+          channels: conda-forge, defaults
+      - uses: actions/checkout@v2
+      - name: install RivGraph + dependencies, then unit test
+        shell: sh -l {0}
+        run: |
+          mamba env create -q --file environment.yml
+          conda activate rivgraph
+          conda uninstall rivgraph
+          pip install pytest pytest-timeout pytest-cov coveralls
+          python setup.py install
+
+          pytest --cov-config=.coveragerc --cov=rivgraph/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,37 @@
+# This workflow installs and tests the RivGraph package
+
+name: build
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: [3.6]
+    env:
+      OS: ${{ matrix.os }}
+      PYTHON: ${{ matrix.python-version }}
+    steps:
+      - uses: conda-incubator/setup-miniconda@v1.7.0
+        with:
+          python-version: ${{ matrix.python-version }}
+          mamba-version: "*"
+          channels: conda-forge, defaults
+      - uses: actions/checkout@v2
+      - name: install RivGraph + dependencies
+        shell: bash -l {0}
+        run: |
+          mamba env create -q --file environment.yml
+          conda activate rivgraph
+          conda uninstall rivgraph
+          sudo apt-get install gnutls-bin
+          pip install pytest pytest-timeout pytest-cov coveralls
+          python setup.py install
+      - name: run unit tests and get coverage
+        run: |
+          pytest --cov-config=.coveragerc --cov=rivgraph/
+          coveralls

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,12 +30,18 @@ jobs:
           conda uninstall rivgraph
           pip install pytest pytest-timeout pytest-cov coveralls
           python setup.py install
-          pytest --cov-config=.coveragerc --cov=rivgraph/
-      - name: get coverage
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          coveralls
+          pytest --cov-config=.coveragerc --cov=rivgraph/ -o coverage.xml
+      - name: generate coverage report
+        uses: danielpalme/ReportGenerator-GitHub-Action@4.7.1
+        with:
+          reports: coverage.xml
+          targetdir: lcov/
+          reporttypes: locv
+      - name: coveralls
+        uses: coverallsapp/github-action@master
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path-to-lcov: lcov/lcov.info
 
   windows-build:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,10 +31,10 @@ jobs:
           pip install pytest pytest-timeout pytest-cov coveralls coverage
           python setup.py install
           coverage run -m pytest --cov-config=.coveragerc --cov=rivgraph/
-      - name: coveralls
       - uses: coverallsapp/github-action@master
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: coveralls
         run: |
           coveralls
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,9 +28,10 @@ jobs:
           mamba env create -q --file environment.yml
           conda activate rivgraph
           conda uninstall rivgraph
-          pip install pytest pytest-timeout pytest-cov coveralls
+          pip install pytest pytest-timeout pytest-cov coveralls coverage
           python setup.py install
-          pytest --cov-config=.coveragerc --cov=rivgraph/ -o coverage.xml
+          coverage run -m pytest --cov-config=.coveragerc --cov=rivgraph/
+          coverage xml -o coverage.xml
       - name: generate coverage report
         uses: danielpalme/ReportGenerator-GitHub-Action@4.7.1
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,18 +31,12 @@ jobs:
           pip install pytest pytest-timeout pytest-cov coveralls coverage
           python setup.py install
           coverage run -m pytest --cov-config=.coveragerc --cov=rivgraph/
-          coverage xml -o coverage.xml
-      - name: generate coverage report
-        uses: danielpalme/ReportGenerator-GitHub-Action@4.7.1
-        with:
-          reports: coverage.xml
-          targetdir: lcov/
-          reporttypes: locv
       - name: coveralls
         uses: coverallsapp/github-action@master
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          path-to-lcov: lcov/lcov.info
+        run: |
+          coveralls
 
   windows-build:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,12 +31,6 @@ jobs:
           pip install pytest pytest-timeout pytest-cov coveralls coverage
           python setup.py install
           coverage run -m pytest --cov-config=.coveragerc --cov=rivgraph/
-      - uses: coverallsapp/github-action@master
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-      - name: coveralls
-        run: |
-          coveralls
 
   windows-build:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
       OS: ${{ matrix.os }}
       PYTHON: ${{ matrix.python-version }}
     steps:
-      - uses: conda-incubator/setup-miniconda@v1.7.0
+      - uses: conda-incubator/setup-miniconda@v2.0.0
         with:
           python-version: ${{ matrix.python-version }}
           mamba-version: "*"
@@ -43,7 +43,7 @@ jobs:
       OS: ${{ matrix.os }}
       PYTHON: ${{ matrix.python-version }}
     steps:
-      - uses: conda-incubator/setup-miniconda@v1.7.0
+      - uses: conda-incubator/setup-miniconda@v2.0.0
         with:
           python-version: ${{ matrix.python-version }}
           miniconda-version: "latest"
@@ -70,7 +70,7 @@ jobs:
       OS: ${{ matrix.os }}
       PYTHON: ${{ matrix.python-version }}
     steps:
-      - uses: conda-incubator/setup-miniconda@v1.7.0
+      - uses: conda-incubator/setup-miniconda@v2.0.0
         with:
           python-version: ${{ matrix.python-version }}
           mamba-version: "*"


### PR DESCRIPTION
Travis-CI is no longer a totally free service, a quote from one of their recent [blog posts](https://blog.travis-ci.com/2020-11-02-travis-ci-new-billing):

> - For those of you who have been building on public repositories (on travis-ci.com, with no paid subscription), we will upgrade you to our trial (free) plan with a 10K credit allotment (which allows around 1000 minutes in a Linux environment).
> - ...
> - When your credit allotment runs out - we’d love for you to consider which of our plans will meet your needs.

So what this PR does is it uses GitHub Actions to build, install, and run the unit tests for RivGraph every time a commit is pushed or a PR to the repository is opened. Besides being free and a part of GitHub, this continuous integration workflow now includes all 3 major operating systems (Windows, MacOS, and Ubuntu). This should help us ensure that new code works on all three operating systems.

The Travis CI stuff is left turned on for now, but I figure it is just a matter of time before we eventually run out of free minutes...