### PR TITLE
Additions to documentation

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -3,7 +3,7 @@ Welcome to RivGraph's documentation!
 
 RivGraph provides two classes that you can instantiate with your binary channel mask: *delta* and (braided) *river*. These classes contain methods that may be applied to execute network extractions, perform analyses, and write (georeferenced) results. While most of RivGraph's processing is automated, deltaic channel networks require the user to also create and provide a shoreline and inlet nodes shapefiles. Guidance for how to create these can be found `here <todo>`_. Take a look at the `FAQ  <todo>`_for quick answers.
 
-If the documentation you seek is not herein, please open a request via the `Issue Tracker <https://github.com/jonschwenk/RivGraph/issues>`_. `Detailed examples <https://github.com/jonschwenk/RivGraph/tree/master/examples>`_ for use are available, and most functions have been documented following a modified `numpy docstring format <https://numpydoc.readthedocs.io/en/latest/format.html>`_. 
+If the documentation you seek is not herein, please open a request via the `Issue Tracker <https://github.com/jonschwenk/RivGraph/issues>`_. `Detailed examples <https://github.com/jonschwenk/RivGraph/tree/master/examples>`_ for use are available, and most functions have been documented following a modified `numpy docstring format <https://numpydoc.readthedocs.io/en/latest/format.html>`_.
 
 Documentation
 -------------
@@ -16,5 +16,6 @@ Documentation
    install/index
    examples/index
    maskmaking/index
+   linksnodes/index
    contributing/index
    apiref/index

--- a/docs/source/linksnodes/index.rst
+++ b/docs/source/linksnodes/index.rst
@@ -1,0 +1,66 @@
+.. _linksnodes:
+
+===========================
+Links and Node Dictionaries
+===========================
+
+After defining a network in *RivGraph* with :obj:`rivgraph.classes.rivnetwork.compute_network()`, two dictionaries will be created:
+**links** and **nodes**.
+This page of the documentation will describe the *keys* present in these dictionaries.
+
+.. note::
+   Not all dictionary key:value pairs are the same length as the number of links or nodes. Some dictionary key:value pairs contain meta-information about the network, or information that only applies to a subset of links/nodes. When the number of key:value pairs matches the number of links or nodes, then they are aligned such that the i'th index of any key:value pair refers to the same link or node.
+
+- :ref:`links`
+- :ref:`nodes`
+
+.. _links:
+
+--------------------
+The Links Dictionary
+--------------------
+
+Links Key Values
+----------------
+
+**N**, represents the number of links.
+
+.. csv-table:: Generic Link Keys
+   :file: links_generic.csv
+   :header-rows: 1
+
+.. csv-table:: Directionality-specific Keys
+   :file: links_dir.csv
+   :header-rows: 1
+
+.. csv-table:: Braided River Exclusive Keys
+   :file: links_river.csv
+   :header-rows: 1
+
+.. csv-table:: Delta Exclusive Keys
+   :file: links_delta.csv
+   :header-rows: 1
+
+Accessing Link Values
+---------------------
+
+For example, if you know the *link_id* of the link you are interested in, you can get its index with :code:`links['id'].index(link_id)`.
+
+.. _nodes:
+
+--------------------
+The Nodes Dictionary
+--------------------
+
+Nodes Key Values
+----------------
+
+**N**, represents the number of nodes.
+
+.. csv-table:: Generic Node Keys
+   :file: nodes_generic.csv
+   :header-rows: 1
+
+Accessing Node Values
+---------------------
+For example, if you wish to find the links connected to :code:`node_id == 66`, you can use :code:`nodes['conn'][nodes['id'].index(66)]`.

--- a/docs/source/linksnodes/links_delta.csv
+++ b/docs/source/linksnodes/links_delta.csv
@@ -1,0 +1,2 @@
+key, type, length, description
+slope, list, N, slope computed from synthetic DEM; note that this has no physical basis and should not be interpreted as actual link slope

--- a/docs/source/linksnodes/links_dir.csv
+++ b/docs/source/linksnodes/links_dir.csv
@@ -1,0 +1,6 @@
+key, type, length, description
+certain, np.array, N, 1 if the link’s direction has been set else 0
+certain_order, np.array, N, describes the order in which links were set. Lower certain_order corresponds to earlier-set links.
+certain_alg, np.array, N, algorithm id of the algorithm ultimately used to set the link direction
+guess, list of lists, N, guesses of the upstream node id for each link; corresponds to guess_alg
+guess_alg, list of lists, N, algorithm id used to compute guess; corresponds to guess

--- a/docs/source/linksnodes/links_generic.csv
+++ b/docs/source/linksnodes/links_generic.csv
@@ -1,0 +1,11 @@
+key, type, length, description
+id, orderedSet, N, unique link id assigned to each link not in a particular order and not guaranteed to skip some id’s
+conn, list of 2-element lists, N, node ids at link endpoints. After running directionality these are in order i.e. [us_nodeid ds_nodeid] 
+idx, list of lists of ints, N, list of the pixel coordinates in index format (via np.ravel_index using the shape of the input binary image) 
+n_networks, int, 1, number of networks identified
+parallels, list of lists, varies, each sublist contains all link ids of links forming a parallel set; i.e. links that start and end at the same node. 
+wid_pix, list of np.arrays, N, width at each pixel of each link (pixels defined by idx) 
+len, list, N, length of each link
+wid, list, N, average width of each link
+len_adj, list, N, length of each link adjusted for accuracy
+wid_adj, list, N, width of each link adjusted for accuracy

--- a/docs/source/linksnodes/links_river.csv
+++ b/docs/source/linksnodes/links_river.csv
@@ -1,0 +1,5 @@
+key, type, length, description
+maxang, np.array, N, ???
+cldists, np.array, N, number of mesh-generated transects each link intersects
+clangs, np.array, N, angle of the link with respect to the valley centerline in radians
+wid_pctdiff, np.array, N, percent difference between the widest and narrowest pixels in a link

--- a/docs/source/linksnodes/nodes_generic.csv
+++ b/docs/source/linksnodes/nodes_generic.csv
@@ -1,0 +1,9 @@
+key, type, length, description
+id, orderedSet, N, unique node id assigned to each node not in a particular order and not guaranteed to skip some id’s
+conn, list of lists, N, link ids of all links connected to this node
+idx, list of lists of ints, N, list of the pixel coordinates in index format (via np.ravel_index using the shape of the input binary image)
+inlets, list of ints, varies, node ids of all nodes identified as inlets
+outlets, list of ints, varies, node ids of all nodes identified as outlets
+int_angle, np.array, N, most interior angle of links connected to each node in degrees; computed via :obj:`rivgraph.ln_utils.junction_angles()`
+jtype, np.array, N, junction type; either ‘c’ (confluence) or ‘b’ (bifurcation); computed via :obj:`rivgraph.ln_utils.junction_angles()`
+width_ratio, np.array, N, ratio of wider link/narrower link for the two links used to compute int_angle; computed via :obj:`rivgraph.ln_utils.junction_angles()`

--- a/docs/source/maskmaking/index.rst
+++ b/docs/source/maskmaking/index.rst
@@ -38,9 +38,9 @@ A mask is simply a binary image (only ones and zeros) where pixels belonging to 
 
 :code:`Mask_binary = np.array(Mask, dtype=np.bool)`
 
-The mask is the cornerstone for using *RivGraph*. You should always ensure that it contains the features you want and none of the ones you don't. 
+The mask is the cornerstone for using *RivGraph*. You should always ensure that it contains the features you want and none of the ones you don't.
 
-.. tip:: Make sure to remove all the objects (connected "on" pixels) in your mask that you do not want to analyze. Leaving in other objects can cause unexpected behavior or `errors <https://github.com/jonschwenk/RivGraph/issues/32>`_. Often, a quick way to achieve this is via the :code:`largest_blobs()` function in `im_utils <https://github.com/jonschwenk/RivGraph/blob/master/rivgraph/im_utils.py>`_, which will keep only the largest connected component.
+.. tip:: Make sure to remove all the objects (connected "on" pixels) in your mask that you do not want to analyze. Leaving in other objects can cause unexpected behavior or `errors <https://github.com/jonschwenk/RivGraph/issues/32>`_. Often, a quick way to achieve this is via the :obj:`rivgraph.im_utils.largest_blobs()` function, which will keep only the largest connected component.
 
 
 
@@ -50,7 +50,7 @@ The mask is the cornerstone for using *RivGraph*. You should always ensure that 
 What should a mask capture?
 ---------------------------
 
-Above, we defined a mask as all the pixels "belonging to the channel network." But which pixels are part of the channel network? The obvious starting point is to consider all *surface water* pixels as defining the channel network. Is it important that your mask shows bankfull channels or includes small streams that may only be active during flood conditions? 
+Above, we defined a mask as all the pixels "belonging to the channel network." But which pixels are part of the channel network? The obvious starting point is to consider all *surface water* pixels as defining the channel network. Is it important that your mask shows bankfull channels or includes small streams that may only be active during flood conditions?
 
 
 .. image:: ../../images/brahma_masks_2004.PNG
@@ -78,14 +78,14 @@ Drawing a mask by hand is often not an ideal choice, but might be the most effic
 tool to convert the polygons to a binary raster (image). If you go this route, be sure to specify an appropriate coordinate reference system for your polygons in order to preserve the georeferencing information (don't use EPSG:4326). You will also need to specify a pixel resolution for your mask upon conversion.
 
 If you're analyzing the output of a simulation, it is unlikely that the simulation will provide binary channel masks as an output. In these cases, you will need to develop a way to identify the channel network from the available simulation results. For example, while developing the entropic Braided Index (`eBI <https://ui.adsabs.harvard.edu/abs/2019AGUFMEP51E2163T/abstract>`_
-), we used Delft3D simulations to test hypotheses about how the eBI changes under various sedimentation schemes. To make masks, we developed a combined depth + discharge threshold to identify which pixels were part of the "active river channel." 
+), we used Delft3D simulations to test hypotheses about how the eBI changes under various sedimentation schemes. To make masks, we developed a combined depth + discharge threshold to identify which pixels were part of the "active river channel."
 
 Here are some resources that either provide masks or tools for you to make your own.
 
 - Published masks:
 
   - `Arctic deltas <https://data.ess-dive.lbl.gov/view/doi:10.15485/1505624>`_, made with eCognition and Landsat imagery.
-  - `Indus and Brahmaputra Rivers <https://esurf.copernicus.org/articles/8/87/2020/#section6>`_, clipped from GRWL dataset. 
+  - `Indus and Brahmaputra Rivers <https://esurf.copernicus.org/articles/8/87/2020/#section6>`_, clipped from GRWL dataset.
   - `Global mask <https://zenodo.org/record/1297434>`_ of Landsat-derived rivers at "mean annual discharge." Has some issues at tile boundaries, and can be "feathery" along braided rivers, but not a bad global mask.
   - `Global Surface Water Dataset <https://global-surface-water.appspot.com/>`_ - provides all water pixels in the Landsat archive as monthly global images and as integrated-through-time images. For example, can threshold on the "Occurrence" product to make a mask. Use `Google Earth Engine <https://developers.google.com/earth-engine/datasets/catalog/JRC_GSW1_2_GlobalSurfaceWater>`_ to access and create your masks.
   - If you know of more, please mention them in the `Issue Tracker <https://github.com/jonschwenk/RivGraph/issues>`_!
@@ -98,7 +98,7 @@ Here are some resources that either provide masks or tools for you to make your 
 
 
 - You can relatively quickly train and apply ML models using `Google Earth Engine <https://earthengine.google.com/>`_, although the learning curve may be a little steep if you haven't used it before.
-  
+
 - `DeepWaterMap  <https://github.com/isikdogan/deepwatermap>`_ is a trained deep convolutional neural network that you can apply to Landsat/Sentinel multispectral imagery to create your own masks. You can also improve DeepWaterMap's base model by adding more training data. Requires some knowledge of Tensorflow.
 
 
@@ -114,7 +114,7 @@ As a mask is simply a single-band image, any pixel-based image editing software 
 
 - These softwares will generally not preserve georeferencing information of your source image. You will have to add it back to the edited image.
 - The softwares may have difficulty opening/editing a single-band image as opposed to the more standard RGB (3 band).
-- Filetypes are sometimes not compatible between Python-exported images and these softwares and will thus require extra attention. 
+- Filetypes are sometimes not compatible between Python-exported images and these softwares and will thus require extra attention.
 
 I have found three effective ways to edit georeferenced masks. The one you choose depends on the quantity and quality of editing you need to achieve.
 
@@ -126,7 +126,7 @@ I have found three effective ways to edit georeferenced masks. The one you choos
 
 2)  `Paint.NET <https://www.getpaint.net/download.html>`_ is an image-editing software that preserves georeferencing information. It's fairly basic and easy to use. If you have a significant amount of hand-editing to do, look into it.
 
-3) Use image processing tools in *RivGraph* to edit your mask. There are morphological operators like :code:`dilate()` and :code:`erode()`, :code:`regionprops()` for filtering objects based on their properties (areas, lengths, perimeters, etc.), and :code:`largest_blobs()` for keeping/removing the largest connected components in the mask. There is also a :code:`hand_clean()` utility that allows you to draw polygons one-at-a-time and specify their pixel values. I usually find these tools sufficient for cleaning a mask, regardless of the amount of editing required. 
+3) Use image processing tools in *RivGraph* to edit your mask. There are morphological operators like :obj:`rivgraph.im_utils.dilate()` and :obj:`rivgraph.im_utils.erode()`, :obj:`rivgraph.im_utils.regionprops()` for filtering objects based on their properties (areas, lengths, perimeters, etc.), and :obj:`rivgraph.im_utils.largest_blobs()` for keeping/removing the largest connected components in the mask. There is also a :obj:`rivgraph.im_utils.hand_clean()` utility that allows you to draw polygons one-at-a-time and specify their pixel values. I usually find these tools sufficient for cleaning a mask, regardless of the amount of editing required.
 
 .. _georef:
 
@@ -140,7 +140,7 @@ Most masks are already produced in a GIS context and are already geographically 
 
 2) *RivGraph* computes morphologic metrics (length and width) using pixel coordinates. A georeferenced mask contains information about the units of the mask, and thus any metrics of physical distance will inherit these units. If your CRS is meters-based, your results will be in meters.
 
-3) Some of *RivGraph*'s functionality under the hood requires some heuristic thresholds or parameters. While these were designed to be as CRS-agnostic as possible, these functions will undoubtedly perform better when pixels have known units. As an example, generating a mesh along a braided river corridor requires some parameters defining the size and smoothness of the mesh. Having a mask with physically-meaningful units makes this parameterization much simpler and more intuitive. 
+3) Some of *RivGraph*'s functionality under the hood requires some heuristic thresholds or parameters. While these were designed to be as CRS-agnostic as possible, these functions will undoubtedly perform better when pixels have known units. As an example, generating a mesh along a braided river corridor requires some parameters defining the size and smoothness of the mesh. Having a mask with physically-meaningful units makes this parameterization much simpler and more intuitive.
 
 .. warning::
   You should **avoid** degree-based CRSs (like EPSG:4326). This is because the length of a degree is not uniform, but varies with latitude. For example, at the equator, a degree of longitude is roughly 111 km. In Anchorage, Alaska, a degree of longitude is approximately 55 km. Effectively, degrees are meaningless units of physical measurements. A more prudent approach would be to first project your mask into a meters-based CRS (e.g. the appropriate `UTM zone <https://en.wikipedia.org/wiki/Universal_Transverse_Mercator_coordinate_system>`_) before analysis with *RivGraph*.
@@ -151,7 +151,7 @@ Most masks are already produced in a GIS context and are already geographically 
 Can my mask represent something that isn't a river?
 ---------------------------------------------------
 
-Perhaps you'd like to vectorize a road network or a vascular system. This is possible to do with *RivGraph*. However, you will not be able to instantiate the convenient *delta* or *river* classes as they are designed only for river channel networks. Instead, you will need to poke around the API to figure out which functions will work for you. A good starting point is to skeletonize your mask with `skeletonize_mask <https://jonschwenk.github.io/RivGraph/apiref/rivgraph.html#rivgraph.mask_to_graph.skeletonize_mask>`_, then run `skel_to_graph  <jonschwenk.github.io/RivGraph/apiref/rivgraph.html#rivgraph.mask_to_graph.skel_to_graph>`_ to convert the skeleton to a set of links and nodes. If you have an interesting non-river use-case, please send an email to j........k@gmail.com and we can add it as an example.
+Perhaps you'd like to vectorize a road network or a vascular system. This is possible to do with *RivGraph*. However, you will not be able to instantiate the convenient *delta* or *river* classes as they are designed only for river channel networks. Instead, you will need to poke around the API to figure out which functions will work for you. A good starting point is to skeletonize your mask with :obj:`rivgraph.mask_to_graph.skeletonize_mask()` then run :obj:`rivgraph.mask_to_graph.skel_to_graph()` to convert the skeleton to a set of links and nodes. If you have an interesting non-river use-case, please send an email to j........k@gmail.com and we can add it as an example.
 
 .. _supportedfiletypes:
 
@@ -160,6 +160,3 @@ What filetypes are supported for my mask?
 -----------------------------------------
 
 Any `gdal-readable filetype <https://gdal.org/drivers/raster/index.html>`_ should be fine. GeoTIFF is most common and recommended if possible.
-
-
-

--- a/rivgraph/walk.py
+++ b/rivgraph/walk.py
@@ -411,8 +411,6 @@ def get_neighbors(idx, Iskel):
 
 def delete_link(linkid, links, nodes):
     """
-    Alias for `ln_utiles.delete_link()`. Retained for existing workflows.
-
     Delete a link from the links dictionary and update the nodes dictionary.
 
     Deletes a link from the links dictionary and updates the nodes dictionary
@@ -437,7 +435,20 @@ def delete_link(linkid, links, nodes):
         Network nodes and associated properties with the link deleted.
 
     """
-    links, nodes = lnu.delete_link(links, nodes, linkid)
+    #TODO: Replace this function with the one in ln_utils.	    links, nodes = lnu.delete_link(links, nodes, linkid)
+
+    # Get index of link within links dict
+    lid = links['id'].index(linkid)
+
+    # Remove the link
+    links['idx'].pop(lid)
+    nodeidx = links['conn'].pop(lid)
+    links['id'].remove(linkid)
+
+    # Remove the link from node connectivity
+    for ni in nodeidx:
+        nodes['conn'][ni].remove(linkid)
+
 
     return links, nodes
 

--- a/rivgraph/walk.py
+++ b/rivgraph/walk.py
@@ -435,7 +435,7 @@ def delete_link(linkid, links, nodes):
         Network nodes and associated properties with the link deleted.
 
     """
-    #TODO: Replace this function with the one in ln_utils.	    links, nodes = lnu.delete_link(links, nodes, linkid)
+    #TODO: Replace this function with the one in ln_utils.
 
     # Get index of link within links dict
     lid = links['id'].index(linkid)

--- a/rivgraph/walk.py
+++ b/rivgraph/walk.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """
 Skeleton Walking Utils (walk.py)
-===============================
+================================
 Functions for walking along skeletons and finding branchpoints.
 
 Created on Mon Sep 10 09:39:19 2018
@@ -411,6 +411,8 @@ def get_neighbors(idx, Iskel):
 
 def delete_link(linkid, links, nodes):
     """
+    Alias for `ln_utiles.delete_link()`. Retained for existing workflows.
+
     Delete a link from the links dictionary and update the nodes dictionary.
 
     Deletes a link from the links dictionary and updates the nodes dictionary
@@ -435,19 +437,7 @@ def delete_link(linkid, links, nodes):
         Network nodes and associated properties with the link deleted.
 
     """
-    #TODO: Replace this function with the one in ln_utils.
-
-    # Get index of link within links dict
-    lid = links['id'].index(linkid)
-
-    # Remove the link
-    links['idx'].pop(lid)
-    nodeidx = links['conn'].pop(lid)
-    links['id'].remove(linkid)
-
-    # Remove the link from node connectivity
-    for ni in nodeidx:
-        nodes['conn'][ni].remove(linkid)
+    links, nodes = lnu.delete_link(links, nodes, linkid)
 
     return links, nodes
 


### PR DESCRIPTION
This PR just adds some stuff to the documentation...

In the "maskmaking" documentation, references to functions are replaced with links to the objects themselves in the API documentation (so references to functions like `dilate()` will be clickable). 

Information about the node/link dictionaries has been added, this was helpful for me so I figured it would be helpful to others if it was part of the actual project documentation. The content itself could probably be better presented/explained but I figure having something is better than nothing. 