### PR TITLE
Unpin gdal

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -5,7 +5,7 @@ channels:
   - defaults
 dependencies:
   - python=3.8
-  - gdal=3.1.4
+  - gdal
   - numpy
   - geopandas=0.7.0
   - scikit-image

--- a/rivgraph/classes.py
+++ b/rivgraph/classes.py
@@ -6,7 +6,10 @@ Classes for running rivgraph commands on your channel network or centerline.
 
 """
 import os
-import gdal
+try:
+    from osgeo import gdal
+except ImportError:
+    import gdal
 import numpy as np
 import networkx as nx
 from pyproj.crs import CRS
@@ -254,8 +257,8 @@ class rivnetwork:
             The default is ['area', 'maxwidth', 'major_axis_length', 'minor_axis_length'].
         connectivity : int, optional
             If 1, 4-connectivity will be used to determine connected blobs. If
-            2, 8-connectivity will be used. The default is 2. 
-            
+            2, 8-connectivity will be used. The default is 2.
+
         Returns
         -------
         islands : geopandas GeoDataFrame
@@ -436,7 +439,7 @@ class rivnetwork:
             - mesh (centerline mesh, river classes only)
 
             - centerline_smooth (river classes only)
-            
+
         ftype : str
             Sets the output file format. Choose from:
 
@@ -877,7 +880,7 @@ class centerline():
         # Store original coordinates
         self.xo = x
         self.yo = y
-        
+
         # Store crs info if provided
         self.crs = crs
 
@@ -1076,16 +1079,16 @@ class centerline():
 
         else:
             print('Could not map intersections to inflection point pairs because infs_os not computed. Run infs() first.')
-            
-            
+
+
     def mig_rate_transect_matching(self, x2, y2, dt_years, path_matchers, x1=None, y1=None, mig_spacing=None, window=None, path_mig_vectors=None):
         """
         Compute migration rate using "transect matching". Requires a user to
-        provide a geovector file (e.g. shapefile, geopackage, etc.) of that 
+        provide a geovector file (e.g. shapefile, geopackage, etc.) of that
         contains transects that intersect both centerlines at their common
         points.
-        
-        Also computes a smoothed version of the migration rates, and a smoothed 
+
+        Also computes a smoothed version of the migration rates, and a smoothed
         version with cutoff-affected points set to NaN.
         """
 
@@ -1096,16 +1099,16 @@ class centerline():
                 window = self.window_C
             else:
                 window = 5  # must be greater than the polyorder, which is 3 by default
-        
+
         if x1 is None:
             x1, y1, _ = self.__get_x_and_y()
-                    
+
         # If no spacing is provided, use 1/8 channel width
         if mig_spacing is None:
             mig_spacing = self.W/8
 
         self.mr_tm, pts_cl1, pts_cl2 = cu.cl_migration_transect_matching(path_matchers, x1, y1, x2, y2, dt_years, mig_spacing)
-        
+
         # Export migration vectors if path provided
         if path_mig_vectors is not None:
             if self.crs is None:
@@ -1118,7 +1121,7 @@ class centerline():
                 gdf_mvs = gpd.GeoDataFrame(geometry=mvs, crs=self.crs)
                 gdf_mvs.to_file(path_mig_vectors, driver=io.get_driver(path_mig_vectors))
 
-         
+
         # Smooth the migration rates
         self.mr_tm_sm = signal.savgol_filter(self.mr_tm, window_length=window,
                                              polyorder=3, mode='interp')
@@ -1136,11 +1139,11 @@ class centerline():
                 self.mr_tm_nan[self.infs_os[e]:self.infs_os[e+1]] = np.NaN
                 self.mr_tm_sm_nan[self.infs_os[e]:self.infs_os[e+1]] = np.NaN
 
-        
+
     def mig_rate_zs(self, x2, y2, dt_years, x1=None, y1=None, window=None):
         """
         Compute migration rate using Sylvester et al's method of
-        dynamic time warping. Also computes a smoothed version of the 
+        dynamic time warping. Also computes a smoothed version of the
         migration rates, and a smoothed version with cutoff-affected
         points set to NaN.
         """
@@ -1300,4 +1303,3 @@ class centerline():
 
         for i in range(0,len(LZC)-1,2):
             ax1.text(s[LZC[i]],0.5,str(i),fontsize=12)
-

--- a/rivgraph/geo_utils.py
+++ b/rivgraph/geo_utils.py
@@ -9,7 +9,10 @@ geographic data including tiffs, vrts, shapefiles, etc.
 functionality here, and some of these functions are simply unused.
 
 """
-import gdal
+try:
+    from osgeo import gdal
+except ImportError:
+    import gdal
 import numpy as np
 from pyproj import Transformer
 import warnings

--- a/rivgraph/io_utils.py
+++ b/rivgraph/io_utils.py
@@ -13,7 +13,10 @@ import os
 import pickle
 import ogr
 import osr
-import gdal
+try:
+    from osgeo import gdal
+except ImportError:
+    import gdal
 import numpy as np
 import pandas as pd
 import geopandas as gpd

--- a/rivgraph/io_utils.py
+++ b/rivgraph/io_utils.py
@@ -11,12 +11,14 @@ Created on Sun Sep 16 15:15:18 2018
 """
 import os
 import pickle
-import ogr
-import osr
 try:
     from osgeo import gdal
+    from osgeo import ogr
+    from osgeo import osr
 except ImportError:
     import gdal
+    import ogr
+    import osr
 import numpy as np
 import pandas as pd
 import geopandas as gpd

--- a/tests/test_geo_utils.py
+++ b/tests/test_geo_utils.py
@@ -7,7 +7,10 @@ import numpy as np
 from rivgraph import geo_utils
 # import osr
 # import ogr
-import gdal
+try:
+    from osgeo import gdal
+except ImportError:
+    import gdal
 from pyproj import CRS
 
 from inspect import getsourcefile

--- a/tests/test_ln_utils.py
+++ b/tests/test_ln_utils.py
@@ -3,7 +3,10 @@
 import sys
 import os
 import io
-import gdal
+try:
+    from osgeo import gdal
+except ImportError:
+    import gdal
 # import numpy as np
 # import matplotlib.pyplot as plt
 


### PR DESCRIPTION
This PR unpins the gdal version requirement by using a more flexible import statement for all osgeo libraries. Thanks to @wrightky for the suggestion.