### PR TITLE
resolve bunch of deprecated code

### DIFF
--- a/rivgraph/deltas/delta_directionality.py
+++ b/rivgraph/deltas/delta_directionality.py
@@ -548,7 +548,7 @@ def dir_synthetic_DEM(links, nodes, imshape):
     alg = dy.algmap('syn_dem')
 
     # Create empty image to store surface
-    I = np.ones(imshape, dtype=np.float)
+    I = np.ones(imshape, dtype=float)
 
     # Get row,col coordinates of outlet nodes, arrange them in a
     # clockwise order
@@ -589,7 +589,7 @@ def dir_synthetic_DEM(links, nodes, imshape):
         hci = hull_coords(insxy)
 
     # Burn the hull into the Iout surface
-    I = np.zeros(imshape, dtype=np.float) + 1
+    I = np.zeros(imshape, dtype=float) + 1
     if hci.shape[0] == 1:
         I[hci[0][0], hci[0][1]] = 0
     else:

--- a/rivgraph/deltas/delta_metrics.py
+++ b/rivgraph/deltas/delta_metrics.py
@@ -66,7 +66,7 @@ def compute_delta_metrics(links, nodes):
 def ensure_single_inlet(links, nodes):
     """
     Ensure only a single apex node exists. This dumbly just prunes all inlet
-    nodes+links except the widest one. Recommended to use the super_apex() 
+    nodes+links except the widest one. Recommended to use the super_apex()
     approach instead if you want to preserve all inlets.
 
     All the delta metrics here require a single apex node, and that that node
@@ -138,37 +138,37 @@ def add_super_apex(links, nodes, imshape):
     have zero length and widths equal to the sum of the widths of the links
     connected to their respective inlet node.
     """
-    
+
     # Get inlet nodes
     ins = nodes['inlets']
-    
+
     if len(ins) <= 1:
         return links, nodes
-    
+
     # Find the location of the super-apex by averaging the inlets' locations
     ins_idx = [nodes['idx'][nodes['id'].index(i)] for i in ins]
     rs, cs = np.unravel_index(ins_idx, imshape)
     apex_r, apex_c = np.mean(rs, dtype=int), np.mean(cs, dtype=int)
     apex_idx = np.ravel_multi_index((apex_r, apex_c), imshape)
-    
+
     # Get the widths of the super-apex links -- these are just the summed
     # widths of all the links connected to each inlet node
     sa_widths = []
     for i in ins:
         lconn = nodes['conn'][nodes['id'].index(i)]
         sa_widths.append(sum([links['wid_adj'][links['id'].index(lid)] for lid in lconn]))
-    
+
     # Add links from the super-apex to the inlet nodes
     # Widths are computed above; lengths are set to zero for these synthetic links
     for i, wid in zip(ins, sa_widths):
         in_idx = nodes['idx'][nodes['id'].index(i)]
         idcs = [apex_idx, in_idx]
-        links, nodes = lnu.add_link(links, nodes, idcs)      
+        links, nodes = lnu.add_link(links, nodes, idcs)
         links['wid_adj'].append(wid)
         links['wid'].append(wid) # we also append to the width attribute to keep the fields the same length
         links['len'].append(0)
         links['len_adj'].append(0)
-        
+
     # Add the super apex node field to the nodes dictionary
     # nodes = ln_utils.add_node(nodes, apex_idx, sa_lids)
     nodes['super_apex'] = nodes['id'][-1]
@@ -188,7 +188,7 @@ def graphiphy(links, nodes, weight=None):
         weights = np.ones((len(links['conn']), 1))
     else:
         weights = np.array(links[weight])
-        
+
     # Check weights
     if np.sum(weights<=0) > 0:
         raise Warning('One or more of your weights is =< 0. This could cause problems later.')
@@ -235,7 +235,7 @@ def intermediate_vars(G):
     # entries a_{uv} that correspond to the fraction of the flux
     # present at node v that flows through the channel (vu). Flux partitioning
     # is done via channel widths.
-    
+
     # Compute normalized weighted adjacency matrix
     A = normalize_adj_matrix(G)
 
@@ -252,7 +252,7 @@ def intermediate_vars(G):
     deltavars['F_w_trans'], deltavars['SubN_w_trans'] = delta_subN_F(deltavars['A_w_trans'])
 
     """ Unweighted Adj"""
-    deltavars['A_uw'] = np.array(deltavars['A_w'].copy(), dtype=np.bool)
+    deltavars['A_uw'] = np.array(deltavars['A_w'].copy(), dtype=bool)
     deltavars['F_uw'], deltavars['SubN_uw'] = delta_subN_F(deltavars['A_uw'])
 
     """ Unweighted transitional"""
@@ -288,12 +288,12 @@ def compute_steady_state_link_fluxes(G, links, nodes):
     run ln_utils artificial_nodes() function to break parallel edges, then
     re-compute link widths and lengths.
     """
-    
+
     # Normalize the adjacency matrix
     An = normalize_adj_matrix(G)
     # Transposed adjacency required for computing F
     An_t = np.transpose(An)
-    # Compute steady-state flux distribution 
+    # Compute steady-state flux distribution
     fluxes, _ = delta_subN_F(An_t)
 
     # Fluxes are at-a-node and need to be translated to links
@@ -306,13 +306,13 @@ def compute_steady_state_link_fluxes(G, links, nodes):
     linkfluxes = np.zeros((len(links['id']),1)) # Preallocate storage
     for (r,c) in zip(rows,cols):
         u = Gnodes[r]
-        v = Gnodes[c]        
+        v = Gnodes[c]
         link_id = G.edges[u,v]['linkid']
         linkfluxes[links['id'].index(link_id)] = fw[r,c]
-    
+
     # Store the fluxes in the links dict
     links['flux_ss'] = np.array(linkfluxes).flatten().tolist()
-    
+
     return links
 
 
@@ -639,7 +639,7 @@ def graphshortestpath(A, start, finish):
     considered. Number of links in the shortest path is returned.
 
     """
-    G = nx.from_numpy_matrix(A)
+    G = nx.from_numpy_array(A)
     sp = nx.shortest_path_length(G, start, finish)
 
     return sp

--- a/rivgraph/directionality.py
+++ b/rivgraph/directionality.py
@@ -1437,7 +1437,7 @@ def set_continuity(links, nodes, checknodes='all'):
         conn = nodes['conn'][nindex]
 
         # Initialize bookkeeping for all the links connected to this node
-        linkdir = np.zeros((len(conn), 1), dtype=np.int)  # 0 if uncertain, 1 if into, 2 if out of
+        linkdir = np.zeros((len(conn), 1), dtype=int)  # 0 if uncertain, 1 if into, 2 if out of
 
         if linkdir.shape[0] < 2:
             continue
@@ -1937,7 +1937,7 @@ def set_artificial_nodes(links, nodes, checknodes='all'):
     Method 1 sets a broken link if its counterpart is known.
     Method 2 sets a side of the loop if the other side is known.
     Method 3 sets both sides if the input to one of the end nodes is known.
-    
+
     Parameters
     ----------
     links : dict
@@ -1947,7 +1947,7 @@ def set_artificial_nodes(links, nodes, checknodes='all'):
     checknodes : int or str, optional
         Node ids to check for presence of settable artificial links. If 'all',
         all nodes in the network are checked.
-    
+
     Returns
     -------
     links : dict

--- a/rivgraph/im_utils.py
+++ b/rivgraph/im_utils.py
@@ -248,7 +248,7 @@ def four_conn(idcs, I):
         Number of four-connected neighbors for each index in idcs.
     """
 
-    Iflat = np.ravel(np.array(I, dtype=np.bool))
+    Iflat = np.ravel(np.array(I, dtype=bool))
 
     fourconn = []
     for i in idcs:
@@ -306,7 +306,7 @@ def neighbor_idcs(c, r):
     column and row.
 
     Returns are ordered as
-    
+
     [0 1 2
      3   4
      5 6 7]
@@ -422,7 +422,7 @@ def neighbor_xy(c, r, idx):
     """
     Returns the coordinates of a neighbor of a pixel given the index of the
     desired neighbor. Indices should be provided according to
-    
+
     [0 1 2
      3   4
      5 6 7].
@@ -444,8 +444,8 @@ def neighbor_xy(c, r, idx):
         Row of the neighbor pixel.
 
     """
-    cs = np.array([-1, 0, 1, -1, 1 , -1, 0, 1], dtype=np.int)
-    rs = np.array([-1, -1, -1, 0, 0, 1, 1, 1], dtype=np.int)
+    cs = np.array([-1, 0, 1, -1, 1 , -1, 0, 1], dtype=int)
+    rs = np.array([-1, -1, -1, 0, 0, 1, 1, 1], dtype=int)
 
     c = c + cs[idx]
     r = r + rs[idx]
@@ -641,7 +641,7 @@ def regionprops(I, props, connectivity=2):
     cant_do = set(props) - set(props_do)
     if len(cant_do) > 0:
         print('Cannot compute the following properties: {}'.format(cant_do))
-    
+
     Ilabeled = measure.label(I, background=0, connectivity=connectivity)
     properties = measure.regionprops(Ilabeled, intensity_image=I)
 
@@ -654,7 +654,7 @@ def regionprops(I, props, connectivity=2):
         if prop == 'area':
             out[prop] = np.array([p.area for p in properties])
         elif prop == 'coords':
-            out[prop] = np.array(coords)
+            out[prop] = list(coords)
         elif prop == 'centroid':
             out[prop] = np.array([p.centroid for p in properties])
         elif prop == 'mean':
@@ -889,7 +889,7 @@ def fill_holes(I, maxholesize=0):
 
     """
 
-    I = np.array(I, dtype=np.bool)
+    I = np.array(I, dtype=bool)
 
     if maxholesize == 0:
         I = nd.morphology.binary_fill_holes(I)
@@ -1343,7 +1343,7 @@ def skel_pixel_curvature(Iskel, nwalk=4):
     px = np.ndarray.tolist(skelpix[:, 1])
 
     # Initialize storage image
-    I = np.zeros_like(Iskel, dtype=np.float)
+    I = np.zeros_like(Iskel, dtype=float)
     I.fill(np.nan)
 
     # Loop through each pixel to compute its curvature
@@ -1456,7 +1456,7 @@ def skel_pixel_curvature(Iskel, nwalk=4):
         if np.isnan(x1):
             if np.ptp(xs1) >= np.ptp(ys1):
                 w1fit = [np.array(xs1, ndmin=2), np.array(ys1, ndmin=2)]
-                m1 = np.linalg.lstsq(w1fit[0].T, w1fit[1].T)[0]
+                m1 = np.linalg.lstsq(w1fit[0].T, w1fit[1].T, rcond=-1)[0]
                 dx = 1 * np.sign(walks[0][0][-1]-walks[0][0][0])
                 if dx == 0:
                     dx = 1
@@ -1464,7 +1464,7 @@ def skel_pixel_curvature(Iskel, nwalk=4):
                 y1 = -m1 * dx
             else:
                 w1fit = [np.array(ys1, ndmin=2), np.array(xs1, ndmin=2)]
-                m1 = np.linalg.lstsq(w1fit[0].T, w1fit[1].T)[0]
+                m1 = np.linalg.lstsq(w1fit[0].T, w1fit[1].T, rcond=-1)[0]
                 dy = -(1 * np.sign(walks[0][1][-1] - walks[0][1][0]))
                 y1 = dy
                 x1 = -m1 * dy
@@ -1472,7 +1472,7 @@ def skel_pixel_curvature(Iskel, nwalk=4):
         if np.isnan(x2):
             if np.ptp(xs2) >= np.ptp(ys2):
                 w2fit = [np.array(xs2, ndmin=2), np.array(ys2, ndmin=2)]
-                m2 = np.linalg.lstsq(w2fit[0].T, w2fit[1].T)[0]
+                m2 = np.linalg.lstsq(w2fit[0].T, w2fit[1].T, rcond=-1)[0]
                 dx = 1 * np.sign(walks[1][0][-1]-walks[1][0][0])
                 if dx == 0:
                     dx = 1
@@ -1480,7 +1480,7 @@ def skel_pixel_curvature(Iskel, nwalk=4):
                 y2 = -m2 * dx
             else:
                 w2fit = [np.array(ys2, ndmin=2), np.array(xs2, ndmin=2)]
-                m2 = np.linalg.lstsq(w2fit[0].T, w2fit[1].T)[0]
+                m2 = np.linalg.lstsq(w2fit[0].T, w2fit[1].T, rcond=-1)[0]
                 dy = -(1 * np.sign(walks[1][1][-1] - walks[1][1][0]))
                 y2 = dy
                 x2 = -m2 * dy

--- a/rivgraph/mask_to_graph.py
+++ b/rivgraph/mask_to_graph.py
@@ -412,8 +412,8 @@ def simplify_skel(Iskel):
             continue
 
         # Create 3x3 array with center pixel removed
-        Inv = np.array([[nv[0], nv[1], nv[2]], [nv[3], 0, nv[4]], [nv[5], nv[6], nv[7]]], dtype=np.bool)
-
+        Inv = np.array([[nv[0], nv[1], nv[2]], [nv[3], 0,
+                         nv[4]], [nv[5], nv[6], nv[7]]], dtype=bool)
 
         # Check the connectivity after removing the pixel, set to zero if unchanged
         Ilabeled = measure.label(Inv, background=0, connectivity=2)
@@ -468,7 +468,7 @@ def pad_river_im(I, es, pm=2):
         pads[0] = (en-st) * pm
 
         # Make pad
-        addpad = np.zeros((pads[0], Ip.shape[1]), dtype=np.bool)
+        addpad = np.zeros((pads[0], Ip.shape[1]), dtype=bool)
         addpad[:,rowidcs] = True
 
         # Add pad to image
@@ -482,7 +482,7 @@ def pad_river_im(I, es, pm=2):
         pads[1] = (en-st) * pm
 
         # Make pad
-        addpad = np.zeros((pads[1], Ip.shape[1]), dtype=np.bool)
+        addpad = np.zeros((pads[1], Ip.shape[1]), dtype=bool)
         addpad[:,rowidcs] = True
 
         # Add pad to image
@@ -496,7 +496,7 @@ def pad_river_im(I, es, pm=2):
         pads[2] = (en-st) * pm
 
         # Make pad
-        addpad = np.zeros((Ip.shape[0], pads[2]), dtype=np.bool)
+        addpad = np.zeros((Ip.shape[0], pads[2]), dtype=bool)
         addpad[colidcs,:] = True
         Ip = np.concatenate((Ip, addpad), axis=1)
 
@@ -508,7 +508,7 @@ def pad_river_im(I, es, pm=2):
         pads[3] = (en-st) * pm
 
         # Make pad
-        addpad = np.zeros((Ip.shape[0], pads[3]), dtype=np.bool)
+        addpad = np.zeros((Ip.shape[0], pads[3]), dtype=bool)
         addpad[colidcs,:] = True
         Ip = np.concatenate((addpad, Ip), axis=1)
 

--- a/rivgraph/mask_utils.py
+++ b/rivgraph/mask_utils.py
@@ -40,7 +40,7 @@ def pixagon(c_cent, r_cent, pixlen):
 
 def get_island_properties(Imask, pixlen, pixarea, crs, gt, props, connectivity=2):
     """Get island properties."""
-    
+
     # maxwidth is an additional property
     if 'maxwidth' in props:
         props.remove('maxwidth')
@@ -54,7 +54,7 @@ def get_island_properties(Imask, pixlen, pixarea, crs, gt, props, connectivity=2
 
     # Pad by one pixel to help identify and remove the outer portion of
     # the channel netowrk
-    Imaskpad = np.array(np.pad(Imask, 1, mode='constant'), dtype=np.bool)
+    Imaskpad = np.array(np.pad(Imask, 1, mode='constant'), dtype=bool)
     Imp_invert = np.invert(Imaskpad)
 
     rp_islands, Ilabeled = iu.regionprops(Imp_invert, props=props, connectivity=connectivity)
@@ -143,7 +143,7 @@ def surrounding_link_properties(links, nodes, Imask, islands, Iislands,
     Imask : np.array
         Binary mask of the channel network.
     islands : geopandas.GeoDataframe
-        Contains island boundaries and associated properties. Created by 
+        Contains island boundaries and associated properties. Created by
         get_island_properties().
     Iislands : np.array
         Image wherein each island has a unique integer ID.
@@ -174,7 +174,7 @@ def surrounding_link_properties(links, nodes, Imask, islands, Iislands,
     # # Iislands = np.load(r'C:\Users\Jon\Desktop\Research\eBI\Results\Indus\Indus_Iislands.npy')
 
     # Rasterize the links and nodes
-    Iln = np.zeros(Imask.shape, dtype=np.int)
+    Iln = np.zeros(Imask.shape, dtype=int)
 
     # Burn links into raster
     for lidcs in links['idx']:
@@ -188,11 +188,11 @@ def surrounding_link_properties(links, nodes, Imask, islands, Iislands,
     # Pad Ilids and Imask to avoid edge effects later
     npad = 8
     Iln = np.pad(Iln, npad, mode='constant')
-    Imask = np.array(np.pad(Imask, npad, mode='constant'), dtype=np.bool)
+    Imask = np.array(np.pad(Imask, npad, mode='constant'), dtype=bool)
     Iislands = np.pad(Iislands, npad, mode='constant')
 
     # Make a binary version of the network skeleton
-    Iskel = np.array(Iln, dtype=np.bool)
+    Iskel = np.array(Iln, dtype=bool)
     # Invert the skeleton
     Iskel = np.invert(Iskel)
 
@@ -241,7 +241,7 @@ def surrounding_link_properties(links, nodes, Imask, islands, Iislands,
 
         # Pad and dilate the blob
         Irblob = np.pad(Irblob, npad, mode='constant')
-        Irblob = np.array(im.dilate(Irblob, n=2, strel='disk'), dtype=np.bool)
+        Irblob = np.array(im.dilate(Irblob, n=2, strel='disk'), dtype=bool)
 
         # Adjust padded image in case pads extend beyond original image boundary
         if cropped[0] - npad < 0:
@@ -363,7 +363,7 @@ def thresholding_set1(islands, apex_width):
 
     # Thresholding
     remove = set()
-    
+
     # Global thresholding -- islands smaller than 1/10 the apex_wid^2
     area_thresh = (1/10 * apex_width)**2
     remove.update(np.where(islands.Area.values < area_thresh)[0].tolist())

--- a/rivgraph/ordered_set.py
+++ b/rivgraph/ordered_set.py
@@ -37,7 +37,7 @@ def is_iterable(obj):
     )
 
 
-class OrderedSet(collections.MutableSet, collections.Sequence):
+class OrderedSet(collections.abc.MutableSet, collections.abc.Sequence):
     """
     An OrderedSet is a custom MutableSet that remembers its order, so that
     every entry has an index that can be looked up.
@@ -287,7 +287,7 @@ class OrderedSet(collections.MutableSet, collections.Sequence):
         """
         # In Python 2 deque is not a Sequence, so treat it as one for
         # consistent behavior with Python 3.
-        if isinstance(other, (collections.Sequence, collections.deque)):
+        if isinstance(other, (collections.abc.Sequence, collections.deque)):
             # Check that this OrderedSet contains the same elements, in the
             # same order, as the other object.
             return list(self) == list(other)

--- a/rivgraph/walk.py
+++ b/rivgraph/walk.py
@@ -642,7 +642,7 @@ def isbp_parsimonious(Ic, Icr, Inar, Infr):
     # possible initial branchpoint
     bpsave = []
     for bpi in bp_poss_i:
-        bptemp = isbp_walk_for_bps(np.array(Ic, dtype=np.bool), [bpi])
+        bptemp = isbp_walk_for_bps(np.array(Ic, dtype=bool), [bpi])
         bpsave.append(bptemp)
 
     # Number of branchpoints for each possible initial branchpoint
@@ -686,7 +686,7 @@ def isbp_parsimonious(Ic, Icr, Inar, Infr):
 
     # Only consider combinations that have branchpoints where they must be placed
     if len(bp_must) > 0:
-        bps = isbp_walk_for_bps(np.array(Ic, dtype=np.bool), bp_must)
+        bps = isbp_walk_for_bps(np.array(Ic, dtype=bool), bp_must)
         return bps
 
     # If there are no branchpoints that must exist based on patterns,


### PR DESCRIPTION
Aims to address #58 but does not solve all warnings.

The below warnings still pop up when running the test suite:

```
tests/test_synthetic.py: 4 warnings
  /home/jayh/anaconda3/envs/rivgraph/lib/python3.8/site-packages/pandas/core/dtypes/cast.py:1981: DeprecationWarning: An exception was ignored while fetching the attribute `__array_interface__` from an object of type 'Polygon'.  With the exception of `AttributeError` NumPy will always raise this exception in the future.  Raise this deprecation warning to see the original exception. (Warning added NumPy 1.21)
    result[:] = values
```

```
tests/test_synthetic.py: 4 warnings
  /home/jayh/anaconda3/envs/rivgraph/lib/python3.8/site-packages/geopandas/array.py:93: DeprecationWarning: An exception was ignored while fetching the attribute `__array_interface__` from an object of type 'Polygon'.  With the exception of `AttributeError` NumPy will always raise this exception in the future.  Raise this deprecation warning to see the original exception. (Warning added NumPy 1.21)
    aout[:] = out
```

```
tests/test_verbosity.py: 88762 warnings
  /home/jayh/anaconda3/envs/rivgraph/lib/python3.8/site-packages/scipy/spatial/distance.py:308: DeprecationWarning: scipy.spatial.distance metrics ignoring length-1 dimensions is deprecated in SciPy 1.7 and will raise an error in SciPy 1.9.
    warnings.warn(
```

```
tests/test_synthetic.py::test_get_islands
  /home/jayh/anaconda3/envs/rivgraph/lib/python3.8/site-packages/numpy/core/fromnumeric.py:1970: VisibleDeprecationWarning: Creating an ndarray from ragged nested sequences (which is a list-or-tuple of lists-or-tuples-or ndarrays with different lengths or shapes) is deprecated. If you meant to do this, you must specify 'dtype=object' when creating the ndarray.
    result = asarray(a).shape
```

```
tests/test_synthetic.py::test_assigning_inletshore
  /home/jayh/anaconda3/envs/rivgraph/lib/python3.8/site-packages/geopandas/geoseries.py:118: DeprecationWarning: The default dtype for empty Series will be 'object' instead of 'float64' in a future version. Specify a dtype explicitly to silence this warning.
    s = pd.Series(data, index=index, name=name, **kwargs)
```

But given that many of these relate to the synthetic simple test case, it may also be that the setup / simplifications in that example are creating unusual scenarios that result in warnings.