### PR TITLE
Update environment.yml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -4,10 +4,10 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - python=3.8
+  - python=3
   - gdal
   - numpy
-  - geopandas=0.7.0
+  - geopandas
   - scikit-image
   - opencv
   - networkx


### PR DESCRIPTION
PR removes explicit python 3.8 and gpd version dependencies from the environment file. Continuous integration is able to successfully install RivGraph, and the tests pass so this would suggest that we can unpin both the python and geopandas versions. 

@jonschwenk if there are specific cases that used to break maybe we should add some specific tests before merging? Let me know if you can think of the scenarios in which the wrong geopandas or python version was breaking things.