### PR TITLE
Print package versions used in testing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,6 +31,7 @@ jobs:
           pip install pytest pytest-timeout pytest-cov coveralls coverage
           python setup.py install
           coverage run -m pytest --cov-config=.coveragerc --cov=rivgraph/
+          conda list
 
   windows-build:
     runs-on: ${{ matrix.os }}
@@ -58,6 +59,7 @@ jobs:
           pip install pytest pytest-timeout pytest-cov coveralls
           python setup.py install
           pytest --cov-config=.coveragerc --cov=rivgraph/
+          conda list
 
   macos-build:
     runs-on: ${{ matrix.os }}
@@ -85,3 +87,4 @@ jobs:
           pip install pytest pytest-timeout pytest-cov coveralls
           python setup.py install
           pytest --cov-config=.coveragerc --cov=rivgraph/
+          conda list


### PR DESCRIPTION
This PR adds a line to print the list of conda packages installed for the unit testing for each OS. This enables us to see which combination of dependencies is working, for example we can see [which version of geopandas is being installed](https://github.com/elbeejay/RivGraph/runs/4740586164?check_suite_focus=true#step:4:645).

I think this could help people resolve issues like #67 and in my opinion would close #45. 

EDIT: I am not sure who is able to look at the GitHub Action logfiles, but at the very least a project maintainer could copy/paste the stable set of dependencies if issues like those above do arise in the future. 
